### PR TITLE
Add ServiceNOW Python scripts for 24 Hour Compliance

### DIFF
--- a/ServiceNow/24hr_compliance_ondemand.py
+++ b/ServiceNow/24hr_compliance_ondemand.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python3
+
+# Bulk On-Demand Snapshot for 24 Hour Compliance
+#
+# Requirements: Python 2.7
+#               rubrik_cdm module
+#               Rubrik CDM 3.0+
+#               Environment variables for RUBRIK_IP (IP of Rubrik node), RUBRIK_USER (Rubrik username), RUBRIK_PASS (Rubrik password)
+
+import rubrik_cdm
+import urllib3
+urllib3.disable_warnings()
+
+debug = 'false'
+
+rubrik = rubrik_cdm.Connect()
+
+table_payload = {
+    "dataSource":"FrequentDataSource",
+    "reportTableRequest":{
+        "sortBy":"ObjectName",
+        "sortOrder":"asc",
+        "requestFilters":{
+            "compliance24HourStatus": "NonCompliance"
+        },
+        "limit": 1000
+    }
+}
+
+events = rubrik.post('internal','/report/data_source/table',table_payload)
+ctr = 0
+
+for event in events['dataGrid']:
+    
+    ctr = ctr + 1
+
+    object_name = event[13]
+    managed_id = event[4]
+    sla_domain_id = event[5]
+    object_type = event[16]
+    sla_name = event[11]
+
+    if (debug == 'false'):
+
+        ods_payload = {
+            "slaId": sla_domain_id,
+        }
+
+        if (object_type == 'Mssql'):
+
+            api_resp = rubrik.post('v1','/mssql/db/' + managed_id + '/snapshot',ods_payload)
+
+        elif (object_type == 'VmwareVirtualMachine'):
+
+            api_resp = rubrik.post('v1','/vmware/vm/' + managed_id + '/snapshot',ods_payload)
+
+        elif (object_type == 'WindowsVolumeGroup'):
+
+            api_resp = rubrik.post('internal','/volume_group/' + managed_id + '/snapshot',ods_payload)
+
+        elif (object_type == 'WindowsFileset'):
+
+            api_resp = rubrik.post('v1','/fileset/' + managed_id + '/snapshot',ods_payload)
+        
+        else:
+            print('Unable to perform On-Demand Snapshot for Object Type: ' + object_type)
+
+        api_resp_log = ('On-Demand Snapshot Started for {} (Object Type: {}) using SLA {}').format(object_name, object_type, sla_name)
+        print(api_resp_log)
+
+    else:
+
+        print('Object Name: ' + object_name + ', Object Type: ' + object_type)
+
+output_str = ('Script Completed - Started an On-Demand Snpashot for {} Out of Compliance Backups.').format(ctr)
+print(output_str)

--- a/ServiceNow/README.md
+++ b/ServiceNow/README.md
@@ -1,0 +1,33 @@
+# ServiceNOW + Rubrik 5.0.2 24 Hour Compliance
+
+These scripts are intended to be used when the Rubrik ServiceNOW Module cannot be installed into ServiceNOW.
+
+This folder pertains 2 scripts:
+    * snow_incident_creation.py
+    * 24_compliance_ondemand.py
+
+Both these scripts require the python rubrik_cdm module to be installed and environmental variables defined for authentication. Refer to the Python SDK page for more info. [rubrik-sdk-for-python](https://github.com/rubrikinc/rubrik-sdk-for-python)
+
+## Snow Incident Creation
+
+The script called `snow_incident_creation.py` is intended to scan the new 24 hour compliance report at a set time, and automatically create an incident for each row item found where the status is 'Non-Compliance'.
+
+This is limited to 1000 items currently, this can be adjusted by changing the `limit` value inside the payload:
+
+```
+table_payload = {
+    "dataSource":"FrequentDataSource",
+    "reportTableRequest":{
+        "sortBy":"ObjectName",
+        "sortOrder":"asc",
+        "requestFilters":{
+            "compliance24HourStatus": "NonCompliance"
+        },
+        "limit": 1000
+    }
+}
+```
+
+## 24 Hour Compliance On-Demand
+
+This script called `24_compliance_ondemand.py` will scan the same report and perform an on-demand snapshot for each item that supports the on-demand snapshot type.

--- a/ServiceNow/README.md
+++ b/ServiceNow/README.md
@@ -12,6 +12,12 @@ Both these scripts require the python rubrik_cdm module to be installed and envi
 
 The script called `snow_incident_creation.py` is intended to scan the new 24 hour compliance report at a set time, and automatically create an incident for each row item found where the status is 'Non-Compliance'.
 
+We need to specify credentials and the serviceNOW instance inside the connection string:
+
+```
+conn = Connection.Auth(username='admin', password='rubrik', instance='dev99999', api='JSONv2')
+```
+
 This is limited to 1000 items currently, this can be adjusted by changing the `limit` value inside the payload:
 
 ```

--- a/ServiceNow/snow_incident_creation.py
+++ b/ServiceNow/snow_incident_creation.py
@@ -1,0 +1,127 @@
+#!/usr/bin/python3
+
+# SNOW Automatic Incident Creation for 24 Hour Compliance
+#
+# Requirements: Python 2.7
+#               rubrik_cdm module (pip install rubrik_cdm)
+#               servicenow module (pip install servicenow)
+#               Rubrik CDM 3.0+
+#               Environment variables for RUBRIK_IP (IP of Rubrik node), RUBRIK_USER (Rubrik username), RUBRIK_PASS (Rubrik password)
+
+from servicenow import ServiceNow
+from servicenow import Connection
+import rubrik_cdm
+
+conn = Connection.Auth(username='admin', password='rubrik', instance='dev99999', api='JSONv2')
+
+rubrik = rubrik_cdm.Connect()
+inc = ServiceNow.Incident(conn)
+
+table_payload = {
+    "dataSource":"FrequentDataSource",
+    "reportTableRequest":{
+        "sortBy":"ObjectName",
+        "sortOrder":"asc",
+        "requestFilters":{
+            "compliance24HourStatus": "NonCompliance"
+        },
+        "limit":1000
+    }
+}
+
+events = rubrik.post('internal','/report/data_source/table',table_payload)
+
+for event in events['dataGrid']:
+
+    incident_description = (
+        'Object Name: ' + event[13] + '\n' +
+        'Location: ' + event[1] + '\n' +
+        'Object Type: ' + event[16] + '\n' +
+        'SLA Domain Name: ' + event[11] + '\n' +
+        'Snapshot Count in last 24 hours: ' + event[2] + '\n' +
+        'Snapshot 24hr Compliance: ' + event[9] + '\n' +
+        'Last Snapshot: ' + event[10] + '\n' +
+        'Latest Archival Snapshot: ' + event[12] + '\n' +
+        'Latest Replication Snapshot: ' + event[15] + '\n' +
+        'Object State: ' + event[6] + '\n')
+    
+    incident_shortname = (
+        'Failed Backup in last 24 hours Object: ' + event[13] + ' in SLA: ' + event[11]
+    )
+
+    incident = {
+        'parent': '', 
+        'made_sla': '', 
+        'caused_by': '', 
+        'watch_list': '', 
+        'upon_reject': 'cancel', 
+        'sys_updated_on': '', 
+        'child_incidents': '', 
+        'hold_reason': '', 
+        'approval_history': '', 
+        'resolved_by': '', 
+        'sys_updated_by': 'admin',  # change this to not use System Administrator account
+        'opened_by': 'Angelo Ferentz',  # Change this to set opened by value
+        'user_input': '', 
+        'sys_created_on': '2018-08-30 08:06:52', 
+        'sys_domain': 'global', 
+        'state': '1', 
+        'sys_created_by': 'admin',  # change this to not use System Administrator account
+        'knowledge': 'false', 
+        'order': '', 
+        '__status': 'success', 
+        'calendar_stc': '', 
+        'closed_at': '', 
+        'business_duration': '', 
+        'group_list': '', 
+        'work_end': '', 
+        'caller_id': 'Angelo Ferentz', #Update this with the Caller Name
+        'reopened_time': '', 
+        'resolved_at': '', 
+        'approval_set': '', 
+        'subcategory': 'ISSUE', 
+        'work_notes': '', 
+        'short_description': incident_shortname, # Uses the shortname incident description defined earlier in the script
+        'close_code': '', 
+        'correlation_display': '', 
+        'delivery_task': '', 
+        'work_start': '', 
+        'assignment_group': '', 
+        'additional_assignee_list': '', 
+        'business_stc': '', 
+        'description': '', 
+        'calendar_duration': '', 
+        'close_notes': '', 
+        'notify': '1', 
+        'service_offering': '', 
+        'sys_class_name': 'incident', 
+        'closed_by': '', 
+        'follow_up': '', 
+        'parent_incident': '', 
+        'sys_id': '57af7aec73d423002728660c4cf6a71c', 
+        'contact_type': '', 
+        'reopened_by': '', 
+        'incident_state': 'Assigned', 
+        'urgency': '4', # Set priority on incident
+        'problem_id': '', 
+        'company': '', 
+        'reassignment_count': '0', 
+        'activity_due': '', 
+        'assigned_to': '',  # set this to defined an assigned to group
+        'severity': '3', # Sets the severity
+        'comments': incident_description, #Sets a description on the incident with the failed backup
+        'approval': 'not requested', 
+        'sla_due': '', 
+        'comments_and_work_notes': '', 
+        'due_date': '', 
+        'sys_mod_count': '4', 
+        'reopen_count': '0', 
+        'sys_tags': '', 
+        'escalation': '0', 
+        'upon_approval': 'proceed', 
+        'correlation_id': '', 
+        'location': '', 
+        'category': 'inquiry'
+        }
+
+    inc.create(incident)


### PR DESCRIPTION
# Description

Scripts to automatically create incidents in SNOW and run an on-demand snapshot against all out of compliance jobs in the 24 Hour Compliance view in 5.0.2

## Motivation and Context

Some customers are unable to use the SNOW module, this uses both the Rubrik and ServiceNOW APIs to work around this.

## How Has This Been Tested?

This has been tested inside a development ServiceNOW instance and against a 5.0.2 cluster in the lab.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/6471505/64604460-1b7c0080-d3ba-11e9-821c-f77912f37e59.png)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
